### PR TITLE
Upgrade to non-preview version of System.CommandLine

### DIFF
--- a/src/Summerdawn.Mcpify.Server/Program.cs
+++ b/src/Summerdawn.Mcpify.Server/Program.cs
@@ -7,7 +7,7 @@ namespace Summerdawn.Mcpify.Server;
 /// <summary>
 /// Main program class for the Mcpify server.
 /// </summary>
-public  class Program
+public class Program
 {
     /// <summary>
     /// Entry point for the Mcpify server application.
@@ -25,18 +25,24 @@ public  class Program
             args = ["--mode=http"];
         }
 
-        var modeOption = new Option<string>("--mode", "The server mode to use")
+        var modeOption = new Option<string>("--mode", "-m")
         {
-            IsRequired = true
+            Description = "The server mode to use.",
+            Required = true
+        }.AcceptOnlyFromAmong("http", "stdio");
+
+        var rootCommand = new RootCommand("MCP server that can run in HTTP or stdio mode")
+        {
+            modeOption
         };
-        modeOption.AddAlias("-m");
-        modeOption.FromAmong("http", "stdio");
+        rootCommand.SetAction(parseResult =>
+        {
+            string mode = parseResult.GetValue(modeOption)!;
 
-        var rootCommand = new RootCommand("MCP server that can run in HTTP or stdio mode");
-        rootCommand.AddOption(modeOption);
-        rootCommand.SetHandler(mode => MainWithMode(args, mode), modeOption);
+            MainWithMode(args, mode);
+        });
 
-        return rootCommand.Invoke(args);
+        return rootCommand.Parse(args).Invoke();
     }
 
     private static void MainWithMode(string[] args, string mode)

--- a/src/Summerdawn.Mcpify.Server/Summerdawn.Mcpify.Server.csproj
+++ b/src/Summerdawn.Mcpify.Server/Summerdawn.Mcpify.Server.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates the command-line parsing logic for the MCP server and upgrades a key package dependency. The changes modernize how command-line options are defined and handled, and ensure compatibility with the latest version of `System.CommandLine`.

**Command-line parsing improvements:**

* Refactored the `--mode`/`-m` option in `Program.cs` to use the newer `System.CommandLine` API, including setting the description, marking it as required, and restricting accepted values to "http" or "stdio". The handler is now set using `SetAction` with direct parsing of the option value.

**Dependency updates:**

* Upgraded the `System.CommandLine` NuGet package from version `2.0.0-beta4.22272.1` to the stable `2.0.1` release in `Summerdawn.Mcpify.Server.csproj`.