### PR TITLE
Standardize test workflows

### DIFF
--- a/.github/workflows/test-mcpify-server.yml
+++ b/.github/workflows/test-mcpify-server.yml
@@ -45,7 +45,7 @@ jobs:
         if: always()
         with:
           name: test-results
-          path: **/test-results.trx
+          path: '**/test-results.trx'
 
   results:
     needs: test
@@ -59,13 +59,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-results
-          path: ./downloaded-test-results
+          path: './downloaded-test-results'
 
       - name: Publish test results
         uses: dorny/test-reporter@v2
         with:
           name: vibe-cli
-          path: ./downloaded-test-results/**/*.trx
+          path: './downloaded-test-results/**/*.trx'
           reporter: dotnet-trx
           fail-on-error: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-mcpify.yml
+++ b/.github/workflows/test-mcpify.yml
@@ -42,7 +42,7 @@ jobs:
         if: always()
         with:
           name: test-results
-          path: **/test-results.trx
+          path: '**/test-results.trx'
   
   results:
     needs: test
@@ -56,13 +56,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: test-results
-          path: ./downloaded-test-results
+          path: './downloaded-test-results'
 
       - name: Publish test results
         uses: dorny/test-reporter@v2
         with:
           name: vibe-cli
-          path: ./downloaded-test-results/**/*.trx
+          path: './downloaded-test-results/**/*.trx'
           reporter: dotnet-trx
           fail-on-error: false
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both the `Mcpify` and `Mcpify.Server` projects to improve consistency, security, and reporting of test results. The main changes include standardizing environment variables, permissions, and artifact handling, as well as introducing a new job for publishing test results using the `dorny/test-reporter` action.

**Workflow improvements and consistency:**

* Added explicit `permissions` and standardized the use of the `DOTNET_VERSION` environment variable in both `.github/workflows/test-mcpify.yml` and `.github/workflows/test-mcpify-server.yml`, improving security and maintainability. [[1]](diffhunk://#diff-205d18bde78d2145ec4e94d411af20ed01357675405d4ee2b6648cc2a039602fR10-R17) [[2]](diffhunk://#diff-e5ae66a2f2b7d14df7da41c073e2234f3cc9e1ca89d5e06368534beb25c509cbL7-R19)
* Updated the `Setup .NET` step to use the shared environment variable for the .NET version, making it easier to manage version updates across workflows. [[1]](diffhunk://#diff-205d18bde78d2145ec4e94d411af20ed01357675405d4ee2b6648cc2a039602fL21-R29) [[2]](diffhunk://#diff-e5ae66a2f2b7d14df7da41c073e2234f3cc9e1ca89d5e06368534beb25c509cbL23-R32)

**Test result handling and reporting:**

* Renamed test result artifact from `test-results-mcpify`/`test-results-mcpify-server` to the standardized `test-results` in both workflows, simplifying artifact management. [[1]](diffhunk://#diff-205d18bde78d2145ec4e94d411af20ed01357675405d4ee2b6648cc2a039602fL36-R68) [[2]](diffhunk://#diff-e5ae66a2f2b7d14df7da41c073e2234f3cc9e1ca89d5e06368534beb25c509cbL38-R71)
* Added a new `results` job in both workflows to download the test results artifact and publish it using the `dorny/test-reporter` action, enabling better visibility and reporting of test outcomes in the GitHub UI. [[1]](diffhunk://#diff-205d18bde78d2145ec4e94d411af20ed01357675405d4ee2b6648cc2a039602fL36-R68) [[2]](diffhunk://#diff-e5ae66a2f2b7d14df7da41c073e2234f3cc9e1ca89d5e06368534beb25c509cbL38-R71)