### PR TITLE
Return correct JSON-RPC error responses for invalid/unparseable requests

### DIFF
--- a/src/Summerdawn.Mcpify/Models/JsonRpcResponse.cs
+++ b/src/Summerdawn.Mcpify/Models/JsonRpcResponse.cs
@@ -18,6 +18,7 @@ public sealed class JsonRpcResponse
     private const int MethodNotFoundCode = -32601;
     private const int InvalidParamsCode = -32602;
     private const int InternalErrorCode = -32603;
+    private const int ParseErrorCode = -32700;
 
     /// <summary>
     /// Gets or sets the JSON-RPC version. Always "2.0".
@@ -73,6 +74,12 @@ public sealed class JsonRpcResponse
         Id = id,
         Result = result ?? EmptyResult
     };
+
+    /// <summary>
+    /// Creates a parse error response.
+    /// </summary>
+    /// <returns>A parse error response.</returns>
+    public static JsonRpcResponse ParseError() => ErrorResponse(default, ParseErrorCode, "Parse Error");
 
     /// <summary>
     /// Creates an invalid request error response.


### PR DESCRIPTION
This pull request improves error handling and logging for both HTTP and stdio MCP request handling, and introduces standardized JSON-RPC error responses. The changes ensure that error responses conform to the JSON-RPC specification and that request completion is consistently logged, even in error scenarios.

**Error handling and response standardization:**

* Added `ParseErrorCode` to `JsonRpcResponse` and implemented the `ParseError()` method to generate standardized parse error responses. [[1]](diffhunk://#diff-2252c99043214040a6685931c6aaa04d66e4ec33cc7afdee469c2d09238a2066R21) [[2]](diffhunk://#diff-2252c99043214040a6685931c6aaa04d66e4ec33cc7afdee469c2d09238a2066R78-R83)
* Updated HTTP and stdio request handlers to return standardized JSON-RPC error responses (`ParseError()` and `InvalidRequest()`) instead of custom error objects when deserialization fails or the request is invalid. [[1]](diffhunk://#diff-3e9ce44db680f22141bb3306bd60c31f6992a3fa4176c7064f3d964b8a194442L50-L64) [[2]](diffhunk://#diff-27de4793c0f614ee013ca46bc65a0ae16fcba1a7b2100391fbb017508ca4cf22R67-R132)

**Logging improvements:**

* Refactored both HTTP and stdio handlers to ensure request completion is logged in a `finally` block, guaranteeing logging occurs for all outcomes, including errors and early returns. [[1]](diffhunk://#diff-3e9ce44db680f22141bb3306bd60c31f6992a3fa4176c7064f3d964b8a194442L89-R95) [[2]](diffhunk://#diff-27de4793c0f614ee013ca46bc65a0ae16fcba1a7b2100391fbb017508ca4cf22R67-R132)

**Other improvements:**

* Simplified error handling in `HandleProtectedResourceAsync` by removing redundant response writing for internal server errors.