### PR TITLE
Add missing permissions to build changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
+      issues: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Otherwise we get a 403 error "Resource not accessible by integration - https://docs.github.com/rest/pulls/pulls#list-pull-requests"