### PR TITLE
Publish server as AOT-compiled binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,24 @@ jobs:
   build-server:
     needs: [validate, build]
     if: ${{ github.event.inputs.publish_server == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
       matrix:
-        rid: [win-x64, win-arm64, linux-x64, linux-arm64, osx-x64, osx-arm64]
+        include:
+          - rid: win-x64
+            os: windows-latest
+          - rid: win-arm64
+            os: windows-latest
+          - rid: linux-x64
+            os: ubuntu-latest
+          - rid: linux-arm64
+            os: ubuntu-24.04-arm
+          - rid: osx-x64
+            os: macos-latest
+          - rid: osx-arm64
+            os: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -95,10 +107,19 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-      
-      - name: Build server for ${{ matrix.rid }}
+
+      - name: Build Server for ${{ matrix.rid }}
+        run: dotnet publish src/Summerdawn.Mcpify.Server/Summerdawn.Mcpify.Server.csproj -c Release -r ${{ matrix.rid }} --self-contained -p:PublishAot=true -p:DebugSymbols=false -p:GenerateDocumentationFile=false -p:IncludeNativeLibrariesForSelfExtract=true -p:StaticWebAssetsEnabled=false -p:IsTransformWebConfigDisabled=true -p:Version=${{ github.event.inputs.version }} -o ./publish/${{ matrix.rid }}
+
+      - name: Package Server for ${{ matrix.rid }} (Windows)
+        if: runner.os == 'Windows'
         run: |
-          dotnet publish src/Summerdawn.Mcpify.Server/Summerdawn.Mcpify.Server.csproj -c Release -r ${{ matrix.rid }} --self-contained -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugSymbols=false -p:GenerateDocumentationFile=false -p:IncludeNativeLibrariesForSelfExtract=true -p:StaticWebAssetsEnabled=false -p:IsTransformWebConfigDisabled=true -p:Version=${{ github.event.inputs.version }} -o ./publish/${{ matrix.rid }}
+          cd ./publish/${{ matrix.rid }}
+          Compress-Archive -Path * -DestinationPath ../../mcpify-server-${{ github.event.inputs.version }}-${{ matrix.rid }}.zip -CompressionLevel Optimal
+
+      - name: Package Server for ${{ matrix.rid }} (Unix)
+        if: runner.os != 'Windows'
+        run: |
           cd ./publish/${{ matrix.rid }}
           zip -r ../../mcpify-server-${{ github.event.inputs.version }}-${{ matrix.rid }}.zip .
       


### PR DESCRIPTION
- Define runner image per platform.
- Use specific ARM64 image for linux-arm64.