### PR TITLE
Fix JsonRpcResponse.InvalidRequest fails to serialize to JSON

### DIFF
--- a/src/Summerdawn.Mcpifier.AspNetCore/Services/McpRouteHandler.cs
+++ b/src/Summerdawn.Mcpifier.AspNetCore/Services/McpRouteHandler.cs
@@ -59,7 +59,7 @@ public class McpRouteHandler(IJsonRpcDispatcher dispatcher, IOptions<McpifierOpt
                 logger.LogWarning("Received null MCP request");
 
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
-                await context.Response.WriteAsJsonAsync<JsonRpcResponse>(JsonRpcResponse.InvalidRequest(default), JsonRpcAndMcpJsonContext.Default.JsonRpcResponse);
+                await context.Response.WriteAsJsonAsync<JsonRpcResponse>(JsonRpcResponse.InvalidRequest(), JsonRpcAndMcpJsonContext.Default.JsonRpcResponse);
 
                 return;
             }

--- a/src/Summerdawn.Mcpifier/Models/JsonRpcResponse.cs
+++ b/src/Summerdawn.Mcpifier/Models/JsonRpcResponse.cs
@@ -13,6 +13,11 @@ public sealed class JsonRpcResponse
     /// </summary>
     public static readonly IReadOnlyDictionary<string, object?> EmptyResult = new Dictionary<string, object?>();
 
+    /// <summary>
+    /// Gets a JsonElement representing a null identifier.
+    /// </summary>
+    private static readonly JsonElement NullId = JsonDocument.Parse("null").RootElement.Clone();
+
     // JSON-RPC 2.0 error codes
     private const int InvalidRequestCode = -32600;
     private const int MethodNotFoundCode = -32601;
@@ -60,7 +65,7 @@ public sealed class JsonRpcResponse
     /// </summary>
     public static JsonRpcResponse Empty { get; } = new()
     {
-        Id = default
+        Id = NullId
     };
 
     /// <summary>
@@ -79,7 +84,13 @@ public sealed class JsonRpcResponse
     /// Creates a parse error response.
     /// </summary>
     /// <returns>A parse error response.</returns>
-    public static JsonRpcResponse ParseError() => ErrorResponse(default, ParseErrorCode, "Parse Error");
+    public static JsonRpcResponse ParseError() => ErrorResponse(NullId, ParseErrorCode, "Parse Error");
+
+    /// <summary>
+    /// Creates an invalid request error response.
+    /// </summary>
+    /// <returns>An invalid request error response.</returns>
+    public static JsonRpcResponse InvalidRequest() => InvalidRequest(NullId);
 
     /// <summary>
     /// Creates an invalid request error response.
@@ -122,7 +133,8 @@ public sealed class JsonRpcResponse
     /// <returns>An error response.</returns>
     public static JsonRpcResponse ErrorResponse(JsonElement id, int code, string message, object? data = null) => new()
     {
-        Id = id,
+        // Substitute undefined/default id values with null so they can be serialized.
+        Id = id.ValueKind == JsonValueKind.Undefined ? NullId : id,
         Result = null,
         Error = new JsonRpcError
         {

--- a/src/Summerdawn.Mcpifier/Services/McpStdioServer.cs
+++ b/src/Summerdawn.Mcpifier/Services/McpStdioServer.cs
@@ -53,7 +53,7 @@ public class McpStdioServer(IStdio stdio, IJsonRpcDispatcher dispatcher, ILogger
                 if (string.IsNullOrWhiteSpace(requestPayload))
                 {
                     // Treat blank/whitespace lines as InvalidRequest
-                    string errorJson = JsonSerializer.Serialize<JsonRpcResponse>(JsonRpcResponse.InvalidRequest(default), JsonRpcAndMcpJsonContext.Default.JsonRpcResponse);
+                    string errorJson = JsonSerializer.Serialize<JsonRpcResponse>(JsonRpcResponse.InvalidRequest(), JsonRpcAndMcpJsonContext.Default.JsonRpcResponse);
                     await writer.WriteLineAsync(errorJson);
                     continue;
                 }
@@ -95,7 +95,7 @@ public class McpStdioServer(IStdio stdio, IJsonRpcDispatcher dispatcher, ILogger
             {
                 logger.LogWarning("Received null MCP request");
 
-                string errorJson = JsonSerializer.Serialize<JsonRpcResponse>(JsonRpcResponse.InvalidRequest(default), JsonRpcAndMcpJsonContext.Default.JsonRpcResponse);
+                string errorJson = JsonSerializer.Serialize<JsonRpcResponse>(JsonRpcResponse.InvalidRequest(), JsonRpcAndMcpJsonContext.Default.JsonRpcResponse);
                 await writer.WriteLineAsync(errorJson);
 
                 return;


### PR DESCRIPTION
This pull request improves the handling of invalid and malformed JSON-RPC requests, ensuring that error responses conform to the JSON-RPC 2.0 specification by properly using a null identifier (`id: null`). It also adds comprehensive tests to verify correct error handling for invalid and null requests.

**Error Response Improvements:**

* Updated `JsonRpcResponse` so that all error responses (such as parse errors and invalid requests) use a proper JSON `null` value for the `id` field instead of `default`, ensuring compliance with the JSON-RPC 2.0 spec. [[1]](diffhunk://#diff-f962de3e227de06479fea236d2703ecfc98ec64b8996bc2da6a5d70469c90b2cR16-R20) [[2]](diffhunk://#diff-f962de3e227de06479fea236d2703ecfc98ec64b8996bc2da6a5d70469c90b2cL63-R68) [[3]](diffhunk://#diff-f962de3e227de06479fea236d2703ecfc98ec64b8996bc2da6a5d70469c90b2cL82-R93) [[4]](diffhunk://#diff-f962de3e227de06479fea236d2703ecfc98ec64b8996bc2da6a5d70469c90b2cL125-R137)
* Refactored code in `McpRouteHandler` and `McpStdioServer` to use the new `InvalidRequest()` method without passing a default id, further standardizing error responses. [[1]](diffhunk://#diff-f6dcf7553605a8c43962e942f6fb2ce0c2b4e7e2e7360dd17ab30b40b8961f6aL62-R62) [[2]](diffhunk://#diff-8ba37397b76a345105ec7599475c7661a9d2fbd3cbb9e3b7177b6b453a9915bdL56-R56) [[3]](diffhunk://#diff-8ba37397b76a345105ec7599475c7661a9d2fbd3cbb9e3b7177b6b453a9915bdL98-R98)

**Testing Enhancements:**

* Added new tests in `McpRouteHandlerTests` to verify that invalid JSON and null requests return the correct HTTP status code and JSON-RPC error code, and that the dispatcher is not called in these cases.