### PR TITLE
Fix Swagger converter breaks on some circular schema references

### DIFF
--- a/src/Summerdawn.Mcpifier/Services/Swagger/SwaggerConverter.cs
+++ b/src/Summerdawn.Mcpifier/Services/Swagger/SwaggerConverter.cs
@@ -108,6 +108,9 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
             throw new InvalidOperationException($"Failed to read or parse OpenAPI document: {ex.Message}", ex);
         }
 
+        // Create schema resolution cache once for the entire document conversion.
+        var schemaCache = new HashSet<IOpenApiSchema>(SchemaReferenceEqualityComparer.Instance);
+
         var tools = new List<McpifierToolMapping>();
 
         foreach (var pathItem in document.Paths)
@@ -119,7 +122,7 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
             {
                 try
                 {
-                    var tool = await ConvertOperationAsync(path, operation.Key, operation.Value);
+                    var tool = await ConvertOperationAsync(path, operation.Key, operation.Value, schemaCache);
                     tools.Add(tool);
                     logger.LogDebug("Converted operation: {Method} {Path} -> {ToolName}", operation.Key, path, tool.Mcp.Name);
                 }
@@ -156,12 +159,13 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
     /// <param name="path">The API path.</param>
     /// <param name="type">The HTTP operation type.</param>
     /// <param name="operation">The OpenAPI operation.</param>
+    /// <param name="schemaCache">Set used to cache already resolved schemas.</param>
     /// <returns>A tool mapping.</returns>
-    private async Task<McpifierToolMapping> ConvertOperationAsync(string path, HttpMethod type, OpenApiOperation operation)
+    private async Task<McpifierToolMapping> ConvertOperationAsync(string path, HttpMethod type, OpenApiOperation operation, HashSet<IOpenApiSchema> schemaCache)
     {
         string toolName = GenerateToolName(operation, path, type);
-        var (schemaElement, schemaObject) = await BuildInputSchemaAsync(operation);
-        var restConfig = BuildRestConfiguration(path, type, operation);
+        var (schemaElement, schemaObject) = await BuildInputSchemaAsync(operation, schemaCache);
+        var restConfig = BuildRestConfiguration(path, type, operation, schemaCache);
 
         var tool = new McpToolDefinition
         {
@@ -183,8 +187,9 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
     /// Builds the input schema from operation parameters and request body.
     /// </summary>
     /// <param name="operation">The OpenAPI operation.</param>
+    /// <param name="schemaCache">Set used to cache already resolved schemas.</param>
     /// <returns>A tuple containing the JsonElement and JsonSchema representations.</returns>
-    private async Task<(JsonElement schemaElement, JsonSchema schemaObject)> BuildInputSchemaAsync(OpenApiOperation operation)
+    private async Task<(JsonElement schemaElement, JsonSchema schemaObject)> BuildInputSchemaAsync(OpenApiOperation operation, HashSet<IOpenApiSchema> schemaCache)
     {
         // Create initial input schema.
         var jsonBuilder = new StringBuilder();
@@ -196,7 +201,7 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
         // Add request body to input schema, if present.
         if (operation.RequestBody?.Content?.TryGetValue("application/json", out var requestBody) == true)
         {
-            var schema = ResolveSchema(requestBody.Schema);
+            var schema = ResolveSchema(requestBody.Schema, schemaCache);
 
             if (schema is not null)
             {
@@ -218,7 +223,7 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
 
         foreach (var param in operation.Parameters ?? [])
         {
-            var schema = ResolveSchema(param.Schema);
+            var schema = ResolveSchema(param.Schema, schemaCache);
 
             if (schema is null)
             {
@@ -274,8 +279,9 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
     /// <param name="path">The API path.</param>
     /// <param name="type">The HTTP operation type.</param>
     /// <param name="operation">The OpenAPI operation.</param>
+    /// <param name="schemaCache">Set used to cache already resolved schemas.</param>
     /// <returns>A REST configuration.</returns>
-    private RestConfiguration BuildRestConfiguration(string path, HttpMethod type, OpenApiOperation operation)
+    private RestConfiguration BuildRestConfiguration(string path, HttpMethod type, OpenApiOperation operation, HashSet<IOpenApiSchema> schemaCache)
     {
         var config = new RestConfiguration
         {
@@ -297,7 +303,7 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
         // Build request body template
         if (operation.RequestBody?.Content?.TryGetValue("application/json", out var mediaType) == true)
         {
-            var schema = ResolveSchema(mediaType.Schema);
+            var schema = ResolveSchema(mediaType.Schema, schemaCache);
 
             if (schema is not null)
             {
@@ -385,38 +391,56 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
     /// <summary>
     /// Resolves any references (including nested) in the specified schema.
     /// </summary>
-    private static IOpenApiSchema? ResolveSchema(IOpenApiSchema? schema)
+    /// <param name="schema">The schema to resolve.</param>
+    /// <param name="cache">Set used to cache already resolved schemas.</param>
+    private static IOpenApiSchema? ResolveSchema(IOpenApiSchema? schema, HashSet<IOpenApiSchema> cache)
     {
-        return ResolveSchemaTree(schema, new HashSet<IOpenApiSchema>(SchemaReferenceEqualityComparer.Instance));
+        return ResolveSchemaTree(schema, cache, new HashSet<IOpenApiSchema>(SchemaReferenceEqualityComparer.Instance));
     }
 
     /// <summary>
     /// Recursively resolves references throughout a schema subtree while avoiding cycles.
     /// </summary>
     /// <param name="schema">The schema to resolve.</param>
-    /// <param name="visited">Set used to track visited schemas.</param>
-    /// <returns>The resolved schema, or null if none.</returns>
-    private static IOpenApiSchema? ResolveSchemaTree(IOpenApiSchema? schema, HashSet<IOpenApiSchema> visited)
+    /// <param name="cache">Set used to cache already resolved schemas.</param>
+    /// <param name="ancestors">Set used to track schemas in the current path.</param>
+    /// <returns>The resolved schema, or null if none or circular reference.</returns>
+    private static IOpenApiSchema? ResolveSchemaTree(IOpenApiSchema? schema, HashSet<IOpenApiSchema> cache, HashSet<IOpenApiSchema> ancestors)
     {
         schema = UnwrapReference(schema);
 
-        if (schema is null || !visited.Add(schema))
+        if (schema is null)
+        {
+            return schema;
+        }
+
+        // If this schema is an ancestor in the current path, it's a circular reference - prune it.
+        if (ancestors.Contains(schema))
+        {
+            return null;
+        }
+
+        // If we've already fully processed this schema, return it as-is (allows reuse across branches).
+        if (cache.Contains(schema))
         {
             return schema;
         }
 
         if (schema is OpenApiSchema concrete)
         {
-            concrete.Items = ResolveSchemaTree(concrete.Items, visited);
-            concrete.Not = ResolveSchemaTree(concrete.Not, visited);
-            concrete.AdditionalProperties = ResolveSchemaTree(concrete.AdditionalProperties, visited);
+            // Add to ancestors while processing this schema's children.
+            ancestors.Add(schema);
+
+            concrete.Items = ResolveSchemaTree(concrete.Items, cache, ancestors);
+            concrete.Not = ResolveSchemaTree(concrete.Not, cache, ancestors);
+            concrete.AdditionalProperties = ResolveSchemaTree(concrete.AdditionalProperties, cache, ancestors);
 
             if (concrete.Properties is not null && concrete.Properties.Count > 0)
             {
                 string[] propertyNames = concrete.Properties.Keys.ToArray();
                 foreach (string propertyName in propertyNames)
                 {
-                    var resolvedProperty = ResolveSchemaTree(concrete.Properties[propertyName], visited);
+                    var resolvedProperty = ResolveSchemaTree(concrete.Properties[propertyName], cache, ancestors);
                     if (resolvedProperty is null)
                     {
                         concrete.Properties.Remove(propertyName);
@@ -428,12 +452,17 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
                 }
             }
 
-            ResolveSchemaCollection(concrete.AllOf, visited);
-            ResolveSchemaCollection(concrete.AnyOf, visited);
-            ResolveSchemaCollection(concrete.OneOf, visited);
+            ResolveSchemaCollection(concrete.AllOf, cache, ancestors);
+            ResolveSchemaCollection(concrete.AnyOf, cache, ancestors);
+            ResolveSchemaCollection(concrete.OneOf, cache, ancestors);
+
+            // Remove from ancestors after processing.
+            ancestors.Remove(schema);
         }
 
-        visited.Remove(schema);
+        // Cache the schema once fully processed.
+        cache.Add(schema);
+
         return schema;
     }
 
@@ -441,8 +470,9 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
     /// Resolves references for every schema within a collection.
     /// </summary>
     /// <param name="collection">The schema collection to process.</param>
-    /// <param name="visited">Set used to track visited schemas.</param>
-    private static void ResolveSchemaCollection(IList<IOpenApiSchema>? collection, HashSet<IOpenApiSchema> visited)
+    /// <param name="cache">Set used to cache already resolved schemas.</param>
+    /// <param name="ancestors">Set used to track schemas in the current path.</param>
+    private static void ResolveSchemaCollection(IList<IOpenApiSchema>? collection, HashSet<IOpenApiSchema> cache, HashSet<IOpenApiSchema> ancestors)
     {
         if (collection is null)
         {
@@ -451,7 +481,7 @@ public class SwaggerConverter(IHttpClientFactory httpClientFactory, ILogger<Swag
 
         for (int index = 0; index < collection.Count; index++)
         {
-            var resolvedItem = ResolveSchemaTree(collection[index], visited);
+            var resolvedItem = ResolveSchemaTree(collection[index], cache, ancestors);
             if (resolvedItem is not null)
             {
                 collection[index] = resolvedItem;


### PR DESCRIPTION
This pull request improves the schema resolution logic in the Swagger-to-Mcpifier conversion process. The main enhancement is the introduction of a shared schema resolution cache that prevents redundant processing and better handles circular references across the entire document. Several methods now accept and utilize this cache, and the recursive schema resolution logic has been refactored for clarity and efficiency.

**Schema resolution improvements:**

* Added a shared `schemaCache` (a `HashSet<IOpenApiSchema>`) to cache already resolved schemas during the entire document conversion, preventing redundant work and improving circular reference handling.
* Refactored the `ResolveSchema` and `ResolveSchemaTree` methods to use both a global cache and a per-call ancestor set, ensuring proper detection and pruning of circular references and marking schemas as fully processed. [[1]](diffhunk://#diff-11ca3faa7a5400be6adccc387bc6691a89d51427ac4932a09a8666968bff651aL388-R443) [[2]](diffhunk://#diff-11ca3faa7a5400be6adccc387bc6691a89d51427ac4932a09a8666968bff651aL431-R474)
* Updated `ResolveSchemaCollection` to use the new cache and ancestor tracking, improving consistency in schema collection processing.

**Method signature and call updates:**

* Modified `ConvertOperationAsync`, `BuildInputSchemaAsync`, and `BuildRestConfiguration` to accept and pass along the shared `schemaCache`. [[1]](diffhunk://#diff-11ca3faa7a5400be6adccc387bc6691a89d51427ac4932a09a8666968bff651aL122-R125) [[2]](diffhunk://#diff-11ca3faa7a5400be6adccc387bc6691a89d51427ac4932a09a8666968bff651aR162-R168) [[3]](diffhunk://#diff-11ca3faa7a5400be6adccc387bc6691a89d51427ac4932a09a8666968bff651aR282-R284)
* Updated all internal calls to `ResolveSchema` to pass the shared cache, ensuring all schema resolutions benefit from caching and cycle detection. [[1]](diffhunk://#diff-11ca3faa7a5400be6adccc387bc6691a89d51427ac4932a09a8666968bff651aL199-R204) [[2]](diffhunk://#diff-11ca3faa7a5400be6adccc387bc6691a89d51427ac4932a09a8666968bff651aL221-R226) [[3]](diffhunk://#diff-11ca3faa7a5400be6adccc387bc6691a89d51427ac4932a09a8666968bff651aL300-R306)