### PR TITLE
Use .gitattributes to force correct line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize text files to LF in the repository
+* text=auto
+
+# Scripts need platform-specific checkout endings
+*.sh text eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/Mcpifier.slnx
+++ b/Mcpifier.slnx
@@ -9,6 +9,7 @@
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
+    <File Path=".gitattributes" />
     <File Path=".gitignore" />
     <File Path="Directory.Build.props" />
   </Folder>


### PR DESCRIPTION
This pull request introduces a `.gitattributes` file to the repository and adds it to the solution items in `Mcpifier.slnx`. The main purpose is to standardize line endings for text files and scripts, which helps prevent issues with inconsistent line endings across different development environments.

Repository configuration:

* Added a `.gitattributes` file that enforces LF line endings for text files and specifies platform-appropriate line endings for script files (`.sh`, `.cmd`, `.bat`).
* Included `.gitattributes` as a solution item in `Mcpifier.slnx` for better visibility and management within the solution.